### PR TITLE
Pass non-interactive flag (-y) to disable tty

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ ENV PATH=/home/rust/.cargo/bin:/usr/local/musl/bin:/usr/local/bin:/usr/bin:/bin
 # interact with the user or fool around with TTYs.  We also set the default
 # `--target` to musl so that our users don't need to keep overriding it
 # manually.
-RUN curl https://sh.rustup.rs -sSf | sed 's,run "$_file" < /dev/tty,run "$_file" -y,' | sh && \
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y && \
     rustup default stable && \
     rustup target add x86_64-unknown-linux-musl
 ADD cargo-config.toml /home/rust/.cargo/config


### PR DESCRIPTION
rustup-init.sh has a -y flag that disables the prompt.

Flag is in rustup-init.sh:

https://github.com/rust-lang-nursery/rustup.rs/blob/72b9821072abb95cc733d22ca1773ef49b8c9b85/rustup-init.sh#L51-L62