### PR TITLE
Pass openssldir to OpenSSL config script.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,7 @@ WORKDIR /home/rust/libs
 RUN VERS=1.0.2j && \
     curl -O https://www.openssl.org/source/openssl-$VERS.tar.gz && \
     tar xvzf openssl-$VERS.tar.gz && cd openssl-$VERS && \
-    env CC=musl-gcc ./config --prefix=/usr/local/musl && \
+    env CC=musl-gcc ./config --prefix=/usr/local/musl --openssldir=/etc/ssl && \
     env C_INCLUDE_PATH=/usr/local/musl/include/ make depend && \
     make && sudo make install && \
     cd .. && rm -rf openssl-$VERS.tar.gz openssl-$VERS


### PR DESCRIPTION
This controls where the built OpenSSL library will look for ca
certificates.  When you don't provide this, it uses $(prefix)/ssl by
default.

Since no OS is likely to have ca certificates installed in this
location, apps built with this image can have problems validating
certificates.

Setting openssldir to `/etc/ssl` allows apps to work out the box on
debian, ubuntu, core OS, alpine & probably others.  Might not work for
all distros, but should be better than none.