### PR TITLE
switch from ubuntu to debian base for smaller build bot images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,4 @@
-# Use Debian 16.04 as the base for our Rust musl toolchain, because of
-# https://github.com/rust-lang/rust/issues/34978 (as of Rust 1.11).
-FROM ubuntu:16.04
+FROM debian:jessie
 
 # The Rust toolchain to use when building our image.  Set by `hooks/build`.
 ARG TOOLCHAIN=stable


### PR DESCRIPTION
Shrink the rust musl build bot Docker image, by using a leaner base image. Debian shaves off a few MB compared to Ubuntu.

Tested the debian-based build bot by compiling https://github.com/mcandre/ios7crypt-rs .

Note that the current Dockerfile in master actually builds to 600-700MB with Ubuntu/Debian bases, while the old DockerHub images report as 200-300MB. Perhaps recent packages for the rust build bot have grown in size?