### PR TITLE
Added libpq-dev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ RUN apt-get update && \
         curl \
         file \
         git \
+        libpq-dev \
         musl-tools \
         sudo \
         xutils-dev \


### PR DESCRIPTION
Hello!

I'm currently maintaining a branch which includes libpq-dev (PostgreSQL development package) for a Rust application I'm maintaining which uses Diesel and PostgreSQL.

I think it might be valuable to have the popular database development packages installed as I don't believe it's uncommon for applications to talk to databases, and the header files are required to build the majority of database client libraries.  This PR just adds the required package for PostgreSQL, but SQLite and MySQL headers could potentially be good to have too.

Please feel free to close if you're not comfortable with the extra dependency, I'm happy to maintain this fork for my own purposes.