### PR TITLE
update openssl from 1.0.2j to 1.0.2l

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,7 @@ WORKDIR /home/rust/libs
 
 # Build a static library version of OpenSSL using musl-libc.  This is
 # needed by the popular Rust `hyper` crate.
-RUN VERS=1.0.2j && \
+RUN VERS=1.0.2l && \
     curl -O https://www.openssl.org/source/openssl-$VERS.tar.gz && \
     tar xvzf openssl-$VERS.tar.gz && cd openssl-$VERS && \
     env CC=musl-gcc ./config --prefix=/usr/local/musl && \


### PR DESCRIPTION
Signed-off-by: Silvio Fricke <silvio.fricke@gmail.com>