### PR TITLE
Added ARMhf target

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,8 @@ ENV PATH=/home/rust/.cargo/bin:/usr/local/musl/bin:/usr/local/sbin:/usr/local/bi
 # manually.
 RUN curl https://sh.rustup.rs -sSf | \
     sh -s -- -y --default-toolchain $TOOLCHAIN && \
-    rustup target add x86_64-unknown-linux-musl
+    rustup target add x86_64-unknown-linux-musl && \
+    rustup target add armv7-unknown-linux-gnueabihf
 ADD cargo-config.toml /home/rust/.cargo/config
 
 # Set up a `git credentials` helper for using GH_USER and GH_TOKEN to access

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ RUN apt-get update && \
         pkgconf \
         sudo \
         xutils-dev \
+        gcc-4.7-multilib-arm-linux-gnueabihf \
         && \
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
     useradd rust --user-group --create-home --shell /bin/bash --groups sudo

--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@ alias rust-musl-builder='docker run --rm -it -v "$(pwd)":/home/rust/src ekidd/ru
 rust-musl-builder cargo build --release
 ```
 
+To target ARM hard float (Raspberry Pi):
+```sh
+rust-musl-builder cargo build --target=armv7-unknown-linux-gnueabihf --release
+```
+
 This command assumes that `$(pwd)` is readable and writable by uid 1000, gid 1000.  It will output binaries in `target/x86_64-unknown-linux-musl/release`.  At the moment, it doesn't attempt to cache libraries between builds, so this is best reserved for making final release builds.
 
 ## Deploying your Rust application

--- a/cargo-config.toml
+++ b/cargo-config.toml
@@ -2,5 +2,5 @@
 # Target musl-libc by default when running Cargo.
 target = "x86_64-unknown-linux-musl"
 
-[target.arm-unknown-linux-gnueabihf]
+[target.armv7-unknown-linux-gnueabihf]
 linker = "arm-linux-gnueabihf-gcc-4.7"

--- a/cargo-config.toml
+++ b/cargo-config.toml
@@ -1,3 +1,6 @@
 [build]
 # Target musl-libc by default when running Cargo.
 target = "x86_64-unknown-linux-musl"
+
+[target.arm-unknown-linux-gnueabihf]
+linker = "arm-linux-gnueabihf-gcc-4.7"


### PR DESCRIPTION
This PR adds ARMhf (think Raspberry Pi) target and compiler.

```bash
$ $DOCKER_RUN_ALIAS cargo build --target=armv7-unknown-linux-gnueabihf --release

  Compiling hello-arm v0.1.0 (file:///home/rust/src)
  Finished release [optimized] target(s) in 5.25 secs


$ file target/armv7-unknown-linux-gnueabihf/release/hello-arm

target/armv7-unknown-linux-gnueabihf/release/hello-arm: ELF 32-bit LSB shared object,
ARM, EABI5 version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux-armhf.so.3, for
GNU/Linux 3.2.0, BuildID[sha1]=6cc5316eeeccdf66b24decb00515988194be4036,
with debug_info, not stripped
```

Tested OK on Raspberry Pi 2.

Feel free to reject in case ARM doesn't fit the purpose of this image. No hard feelings. Pun intended :)