### PR TITLE
[fix] link zlib statically, with better test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: rust
+
+services:
+  - docker
+
+os:
+  - linux
+
+script:
+- bash ./test-image
+
+notifications:
+  email:
+    on_success: never
+    on_failure: always

--- a/Dockerfile
+++ b/Dockerfile
@@ -96,7 +96,9 @@ ENV OPENSSL_DIR=/usr/local/musl/ \
     PQ_LIB_STATIC_X86_64_UNKNOWN_LINUX_MUSL=1 \
     PG_CONFIG_X86_64_UNKNOWN_LINUX_GNU=/usr/bin/pg_config \
     PKG_CONFIG_ALLOW_CROSS=true \
-    PKG_CONFIG_ALL_STATIC=true
+    PKG_CONFIG_ALL_STATIC=true \
+    LIBZ_SYS_STATIC=1 \
+    TARGET=musl
 
 # (Please feel free to submit pull requests for musl-libc builds of other C
 # libraries needed by the most popular and common Rust crates, to avoid

--- a/test-image
+++ b/test-image
@@ -19,7 +19,26 @@ set -euo pipefail
 export USER=rust
 cargo new --vcs none --bin testme
 cd testme
+# depending on git2 (and using it) makes the test much better, because git2 links against openssl and libz-sys among others
+sed -i 's/\[dependencies\]/\[dependencies\]\ngit2 = \"0.6\"/' Cargo.toml
+echo '
+extern crate git2;
+use git2::Repository;
+fn main() {
+let _local = Repository::init(\"fkbr\");
+println!(\"Hello, world!\");
+}' > src/main.rs
 cargo build
+
+# ldd will not die if the file does not exist, we need to check that too
+if [ ! -f target/x86_64-unknown-linux-musl/debug/testme ]; then
+  echo 'binary was not created by cargo build or has unexpected name. Heres whats in target:' 1>&2
+  # no tree in image, but this also works
+  set -x
+  ls -l target && ls -l target/x86_64-unknown-linux-musl && ls -l target/x86_64-unknown-linux-musl/debug
+  exit 1
+fi
+
 echo 'Checking to make sure it is not a dynamic executable'
 if ldd target/x86_64-unknown-linux-musl/debug/testme; then
   echo 'Executable is not static!' 1>&2


### PR DESCRIPTION
See #41 #38 

Fixes #37

This is basically #38 with the tests encoded using `cargo new` semantics (no docker volume for the project)