### PR TITLE
Fix switch to musl target for ARM static binaries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ ENV PATH=/home/rust/.cargo/bin:/usr/local/musl/bin:/usr/local/sbin:/usr/local/bi
 RUN curl https://sh.rustup.rs -sSf | \
     sh -s -- -y --default-toolchain $TOOLCHAIN && \
     rustup target add x86_64-unknown-linux-musl && \
-    rustup target add armv7-unknown-linux-gnueabihf
+    rustup target add armv7-unknown-linux-musleabihf
 ADD cargo-config.toml /home/rust/.cargo/config
 
 # Set up a `git credentials` helper for using GH_USER and GH_TOKEN to access

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ rust-musl-builder cargo build --release
 
 To target ARM hard float (Raspberry Pi):
 ```sh
-rust-musl-builder cargo build --target=armv7-unknown-linux-gnueabihf --release
+rust-musl-builder cargo build --target=armv7-unknown-linux-musleabihf --release 
 ```
 
 This command assumes that `$(pwd)` is readable and writable by uid 1000, gid 1000.  It will output binaries in `target/x86_64-unknown-linux-musl/release`.  At the moment, it doesn't attempt to cache libraries between builds, so this is best reserved for making final release builds.

--- a/README.md
+++ b/README.md
@@ -9,12 +9,14 @@ alias rust-musl-builder='docker run --rm -it -v "$(pwd)":/home/rust/src ekidd/ru
 rust-musl-builder cargo build --release
 ```
 
+This command assumes that `$(pwd)` is readable and writable by uid 1000, gid 1000. At the moment, it doesn't attempt to cache libraries between builds, so this is best reserved for making final release builds.
+
 To target ARM hard float (Raspberry Pi):
 ```sh
-rust-musl-builder cargo build --target=armv7-unknown-linux-musleabihf --release 
+rust-musl-builder cargo build --target=armv7-unknown-linux-musleabihf --release
 ```
 
-This command assumes that `$(pwd)` is readable and writable by uid 1000, gid 1000.  It will output binaries in `target/x86_64-unknown-linux-musl/release`.  At the moment, it doesn't attempt to cache libraries between builds, so this is best reserved for making final release builds.
+Binaries will be written to `target/$TARGET_ARCHITECTURE/release`. By default it targets `x86_64-unknown-linux-musl` unless specified with `--target`.
 
 ## Deploying your Rust application
 

--- a/cargo-config.toml
+++ b/cargo-config.toml
@@ -2,5 +2,5 @@
 # Target musl-libc by default when running Cargo.
 target = "x86_64-unknown-linux-musl"
 
-[target.armv7-unknown-linux-gnueabihf]
+[target.armv7-unknown-linux-musleabihf]
 linker = "arm-linux-gnueabihf-gcc-4.7"


### PR DESCRIPTION
Fixes https://github.com/emk/rust-musl-builder/pull/40 and produces statically linked ARM binaries.

```sh
# On a Mac

$ $DOCKER_RUN_ALIAS cargo build --target=armv7-unknown-linux-musleabihf --release

   Compiling hello-arm-static v0.1.0 (file:///home/rust/src)
   Finished release [optimized] target(s) in 5.87 secs
```

Binary copied to a Raspberry Pi 2:

```sh
# This is a Raspberry Pi 2

$ uname -a
Linux Pi2 4.9.80-v7+ #1098 SMP Fri Mar 9 19:11:42 GMT 2018 armv7l GNU/Linux

$ ldd hello-arm-static
	not a dynamic executable

$ file hello-arm-static
hello-arm-static: ELF 32-bit LSB executable, ARM, EABI5 version 1 (SYSV),
statically linked, BuildID[sha1]=e45cafee899493b39610565d68e0a4f7e65dab88,
not stripped

$ ./hello-arm-static
Hello, world!
```