### PR TITLE
Added test case for ARMhf static binary

### DIFF
--- a/test-image
+++ b/test-image
@@ -19,14 +19,29 @@ set -euo pipefail
 export USER=rust
 cargo new --vcs none --bin testme
 cd testme
+
+# Add test cases here
+
+echo -e '\nRunning tests...\n'
+
+echo -e '--- Test case for x86_64:'
 cargo build
-echo 'Checking to make sure it is not a dynamic executable'
+echo 'ldd says:'
 if ldd target/x86_64-unknown-linux-musl/debug/testme; then
-  echo 'Executable is not static!' 1>&2
-  echo 'FAIL.' 1>&2
+  echo '[FAIL] Executable is not static!' 1>&2
   exit 1
 fi
+echo -e '[PASS] x86_64 binary is statically linked.\n'
+
+echo -e '--- Test case for ARMhf:'
+cargo build --target=armv7-unknown-linux-musleabihf
+echo 'ldd says:'
+if ldd target/armv7-unknown-linux-musleabihf/debug/testme; then
+  echo '[FAIL] Executable is not static!' 1>&2
+  exit 1
+fi
+echo -e '[PASS] ARMhf binary is statically linked.\n'
 "
 
 # We're good.
-echo 'OK. Tests passed.' 1>&2
+echo 'OK. ALL TESTS PASSED.' 1>&2


### PR DESCRIPTION
Added test case for ARMhf static binary.

Also rearranged the tests a little to make it easier to add more targets in the future. I wanted to use some colors but not sure how Travis CI handles ANSI, so dropped the idea. I can reconsider though :)

`./test-image` now produces:
```
...

Successfully built adce5d11fb8d
Successfully tagged rust-musl-builder-using-diesel:latest
Hello, world!
No DATABASE_URL set, so doing nothing
     Created binary (application) `testme` project

Running tests...

--- Test case for x86_64:
   Compiling testme v0.1.0 (file:///home/rust/src/testme)
    Finished dev [unoptimized + debuginfo] target(s) in 0.73 secs
ldd says:
	not a dynamic executable
[PASS] x86_64 binary is statically linked.

--- Test case for ARMhf:
   Compiling testme v0.1.0 (file:///home/rust/src/testme)
    Finished dev [unoptimized + debuginfo] target(s) in 0.82 secs
ldd says:
	not a dynamic executable
[PASS] ARMhf binary is statically linked.

```