### PR TITLE
Drop Cargo registry caches after cargo-audit installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -115,7 +115,8 @@ ENV OPENSSL_DIR=/usr/local/musl/ \
 
 # Install some useful Rust tools from source. This will use the static linking
 # toolchain, but that should be OK.
-RUN cargo install -f cargo-audit
+RUN cargo install -f cargo-audit && \
+    rm -rf /home/rust/.cargo/registry/
 
 # Expect our source code to live in /home/rust/src.  We'll run the build as
 # user `rust`, which will be uid 1000, gid 1000 outside the container.


### PR DESCRIPTION
This shaves 188MB out of the 1.6GB image.