### PR TITLE
Use bionic and update dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,4 @@
-# Use Debian 16.04 as the base for our Rust musl toolchain, because of
-# https://github.com/rust-lang/rust/issues/34978 (as of Rust 1.11).
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 # The Rust toolchain to use when building our image.  Set by `hooks/build`.
 ARG TOOLCHAIN=stable
@@ -29,7 +27,7 @@ RUN apt-get update && \
         pkgconf \
         sudo \
         xutils-dev \
-        gcc-4.7-multilib-arm-linux-gnueabihf \
+        gcc-8-multilib-arm-linux-gnueabihf \
         && \
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
     useradd rust --user-group --create-home --shell /bin/bash --groups sudo && \
@@ -74,7 +72,7 @@ RUN git config --global credential.https://github.com.helper ghtoken
 # needed by the popular Rust `hyper` crate.
 RUN echo "Building OpenSSL" && \
     cd /tmp && \
-    OPENSSL_VERSION=1.0.2o && \
+    OPENSSL_VERSION=1.0.2q && \
     curl -LO "https://www.openssl.org/source/openssl-$OPENSSL_VERSION.tar.gz" && \
     tar xvzf "openssl-$OPENSSL_VERSION.tar.gz" && cd "openssl-$OPENSSL_VERSION" && \
     env CC=musl-gcc ./Configure no-shared no-zlib -fPIC --prefix=/usr/local/musl linux-x86_64 && \
@@ -91,7 +89,7 @@ RUN echo "Building OpenSSL" && \
     \
     echo "Building libpq" && \
     cd /tmp && \
-    POSTGRESQL_VERSION=9.6.8 && \
+    POSTGRESQL_VERSION=9.6.9 && \
     curl -LO "https://ftp.postgresql.org/pub/source/v$POSTGRESQL_VERSION/postgresql-$POSTGRESQL_VERSION.tar.gz" && \
     tar xzf "postgresql-$POSTGRESQL_VERSION.tar.gz" && cd "postgresql-$POSTGRESQL_VERSION" && \
     CC=musl-gcc CPPFLAGS=-I/usr/local/musl/include LDFLAGS=-L/usr/local/musl/lib ./configure --with-openssl --without-readline --prefix=/usr/local/musl && \


### PR DESCRIPTION
I had trouble building my CLI app with diesel/openssl support. Turns out it does matter the order of  `extern crate foo;` does matter. While I threw everything possible at the wall, I tried building my own rust-musl-builder image.
 
One of the g++ dependency was failing to install, owing to something wrong in the Ubuntu archives no doubt. And I use bionic elsewhere in my infrastructure so I thought it would be helpful to upgrade to a new LTS release. It was pretty easy, the biggest change is dragging in gcc8 libraries vs 4.7.

I also upgrade the custom built dependencies. OpenSSL gets LTS release `1.0.2q`, postgres gets bumped to `9.6.9`.

I don't think the linked issue https://github.com/rust-lang/rust/issues/34978 matters anymore. I have successfully built using this image and I'm happy with it.

Also, pro-tip to anyone who wants to build their own rust-musl for nightly, use docker build's build-args to override the toolchain:

```
docker build --build-arg="TOOLCHAIN=nightly-2019-01-09" -t rust-musl:nightly .
```