### PR TITLE
Port to Ubuntu 18.04, add optional OpenSSL 1.1 support

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -19,8 +19,6 @@ Please include the steps you took, including the commands you ran in your termin
 
 **What did you hope to happen?**
 
-(A clear and concise description of what you expected to happen.)
-
 **Does `./test-image` work?**
 
 If you check out the repository on a Mac or Linux system and run `./build-image`, does it succeed or fail? This will build several known-good examples from the `rust-musl-builder/examples` directory.

--- a/.github/ISSUE_TEMPLATE/build_request.md
+++ b/.github/ISSUE_TEMPLATE/build_request.md
@@ -1,0 +1,12 @@
+---
+name: Build request
+about: Does the image need to be rebuilt?
+title: ''
+labels: bug
+assignees: emk
+
+---
+
+**Rust release:** (stable, X.Y.Z, beta, nightly-YYYY-MM-DD)
+
+**OpenSSL:** 1.0/1.1 (pick one)

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -4,10 +4,10 @@ about: I like hearing suggestions (but I don't always have time to implement the
   unfortunatey).
 title: ''
 labels: enhancement
-assignees: ''
+assignees: emk
 
 ---
 
 **How could this project be improved?**
 
-**If you're interested in implementing this feature yourself, would you like input or mentoring?**
+**If you're interested in implementing this feature yourself, how could I help you?**

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,10 @@ FROM ubuntu:18.04
 # The Rust toolchain to use when building our image.  Set by `hooks/build`.
 ARG TOOLCHAIN=stable
 
+# The OpenSSL version to use. We parameterize this because many Rust
+# projects will fail to build with 1.1.
+ARG OPENSSL_VERSION=1.0.2r
+
 # Make sure we have basic dev tools for building C libraries.  Our goal
 # here is to support the musl-libc builds and Cargo builds needed for a
 # large selection of the most popular crates.
@@ -73,7 +77,6 @@ RUN git config --global credential.https://github.com.helper ghtoken
 # needed by the popular Rust `hyper` crate.
 RUN echo "Building OpenSSL" && \
     cd /tmp && \
-    OPENSSL_VERSION=1.1.1b && \
     curl -LO "https://www.openssl.org/source/openssl-$OPENSSL_VERSION.tar.gz" && \
     tar xvzf "openssl-$OPENSSL_VERSION.tar.gz" && cd "openssl-$OPENSSL_VERSION" && \
     env CC=musl-gcc ./Configure no-shared no-zlib no-async no-engine -fPIC --prefix=/usr/local/musl -DOPENSSL_NO_SECURE_MEMORY linux-x86_64 && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -79,7 +79,7 @@ RUN echo "Building OpenSSL" && \
     cd /tmp && \
     curl -LO "https://www.openssl.org/source/openssl-$OPENSSL_VERSION.tar.gz" && \
     tar xvzf "openssl-$OPENSSL_VERSION.tar.gz" && cd "openssl-$OPENSSL_VERSION" && \
-    env CC=musl-gcc ./Configure no-shared no-zlib no-async no-engine -fPIC --prefix=/usr/local/musl -DOPENSSL_NO_SECURE_MEMORY linux-x86_64 && \
+    env CC=musl-gcc ./Configure no-shared no-zlib -fPIC --prefix=/usr/local/musl -DOPENSSL_NO_SECURE_MEMORY linux-x86_64 && \
     env C_INCLUDE_PATH=/usr/local/musl/include/ make depend && \
     make && sudo make install && \
     rm -r /tmp/*

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ rust-musl-builder sudo chown -R rust:rust \
 
 - The standard `musl-libc` libraries.
 - OpenSSL, which is needed by many Rust applications.
-- `libpq`, which is needed for applications that use `diesel` with PostgreSQL. Note that this may be broken under Rust 1.21.0 and later (see https://github.com/emk/rust-musl-builder/issues/27).
+- `libpq`, which is needed for applications that use `diesel` with PostgreSQL.
 - `libz`, which is needed by `libpq`.
 - SQLite3. See [examples/using-diesel](./examples/using-diesel/).
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,29 @@ Binaries will be written to `target/$TARGET_ARCHITECTURE/release`. By default it
 
 With a bit of luck, you should be able to just copy your application binary from `target/x86_64-unknown-linux-musl/release`, and install it directly on any reasonably modern x86_64 Linux machine.  In particular, you should be able make static release binaries using TravisCI and GitHub, or you can copy your Rust application into an [Alpine Linux container][]. See below for details!
 
+## Available tags
+
+In general, we provide the following tagged Docker images:
+
+- `latest`, `stable`: Current stable Rust, with OpenSSL 1.0 (for now). We
+  try to update this fairly rapidly after every new stable release, and
+  after most point releases.
+- `beta`: This usually gets updated every six weeks alongside the stable
+  release. It will usually not be updated for beta bugfix releases.
+- `nightly-YYYY-MM-DD`: Specific nightly releases. These should almost
+  always support `clippy`, `rls` and `rustfmt`, as verified using
+  [rustup components history][comp]. If you need a specific date for
+  compatibility with `tokio` or another popular library using unstable
+  Rust, please file an issue.
+- `stable-openssl11`: Current stable Rust, with OpenSSL 1.1.
+- `nightly-YYYY-MM-DD-openssl11`: Specific nightly releases with OpenSSL
+  1.1.
+
+At a minimum, each of these images should be able to
+compile [examples/using-diesel](./examples/using-diesel).
+
+[comp]: https://rust-lang.github.io/rustup-components-history/index.html
+
 ## Caching builds
 
 You may be able to speed up build performance by adding the following `-v` commands to the `rust-musl-builder` alias:

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 [![Docker Image](https://img.shields.io/docker/pulls/ekidd/rust-musl-builder.svg?maxAge=2592000)](https://hub.docker.com/r/ekidd/rust-musl-builder/)
 
+**NOTE:** The underlying build image is now running Ubuntu 18.04 and newer
+versions of several libraries. Please report any problems!
+
 Do you want to compile a completely static Rust binary with no external dependencies?  If so, try:
 
 ```sh
@@ -11,13 +14,7 @@ rust-musl-builder cargo build --release
 
 This command assumes that `$(pwd)` is readable and writable by uid 1000, gid 1000. At the moment, it doesn't attempt to cache libraries between builds, so this is best reserved for making final release builds.
 
-To target ARM hard float (Raspberry Pi):
-
-```sh
-rust-musl-builder cargo build --target=armv7-unknown-linux-musleabihf --release
-```
-
-Binaries will be written to `target/$TARGET_ARCHITECTURE/release`. By default it targets `x86_64-unknown-linux-musl` unless specified with `--target`.
+For a more realistic example, see the `Dockerfile` for [examples/using-diesel](./examples/using-diesel).
 
 ## Deploying your Rust application
 
@@ -30,6 +27,7 @@ In general, we provide the following tagged Docker images:
 - `latest`, `stable`: Current stable Rust, with OpenSSL 1.0 (for now). We
   try to update this fairly rapidly after every new stable release, and
   after most point releases.
+- `X.Y.Z`: Specific versions of stable Rust.
 - `beta`: This usually gets updated every six weeks alongside the stable
   release. It will usually not be updated for beta bugfix releases.
 - `nightly-YYYY-MM-DD`: Specific nightly releases. These should almost
@@ -38,7 +36,8 @@ In general, we provide the following tagged Docker images:
   compatibility with `tokio` or another popular library using unstable
   Rust, please file an issue.
 - `stable-openssl11`: Current stable Rust, with OpenSSL 1.1.
-- `nightly-YYYY-MM-DD-openssl11`: Specific nightly releases with OpenSSL
+- `X.Y.Z-openssl11`: Specific versions of stable Rust, with OpenSSL 1.1.
+- `nightly-YYYY-MM-DD-openssl11`: Specific nightly releases, with OpenSSL
   1.1.
 
 At a minimum, each of these images should be able to
@@ -185,6 +184,18 @@ Docker now supports [multistage builds][multistage], which make it easy to build
 If you're using Docker crates which require specific C libraries to be installed, you can create a `Dockerfile` based on this one, and use `musl-gcc` to compile the libraries you need.  For an example, see [`examples/adding-a-library/Dockerfile`](./examples/adding-a-library/Dockerfile). This usually involves a bit of experimentation for each new library, but it seems to work well for most simple, standalone libraries.
 
 If you need an especially common library, please feel free to submit a pull request adding it to the main `Dockerfile`!  We'd like to support popular Rust crates out of the box.
+
+## ARM support (experimental)
+
+To target ARM hard float (Raspberry Pi):
+
+```sh
+rust-musl-builder cargo build --target=armv7-unknown-linux-musleabihf --release
+```
+
+Binaries will be written to `target/$TARGET_ARCHITECTURE/release`. By default it targets `x86_64-unknown-linux-musl` unless specified with `--target`.
+
+This is missing many of the libraries used by the `x86_64` build, and it should probably be split out of the base image and given its own tags.
 
 ## Development notes
 

--- a/cargo-config.toml
+++ b/cargo-config.toml
@@ -3,4 +3,4 @@
 target = "x86_64-unknown-linux-musl"
 
 [target.armv7-unknown-linux-musleabihf]
-linker = "arm-linux-gnueabihf-gcc-4.7"
+linker = "arm-linux-gnueabihf-gcc"

--- a/examples/using-diesel/Dockerfile
+++ b/examples/using-diesel/Dockerfile
@@ -3,8 +3,12 @@
 # An example Dockerfile showing how to build a Rust executable using this
 # image, and deploy it with a tiny Alpine Linux container.
 
+# You can override this `--build-arg BASE_IMAGE=...` to use different
+# version of Rust or OpenSSL.
+ARG BASE_IMAGE=ekidd/rust-musl-builder:latest
+
 # Our first FROM statement declares the build environment.
-FROM ekidd/rust-musl-builder AS builder
+FROM ${BASE_IMAGE} AS builder
 
 # Add our source code.
 ADD . ./

--- a/hooks/build
+++ b/hooks/build
@@ -1,23 +1,47 @@
 #!/bin/bash
+#
+# This script is responsible for calling `docker build` on behalf of GitHub. But
+# what it _really_ does is translate `DOCKER_TAG` into the builds args `TARGET`
+# and `OPENSSL_VERSION`.
 
 # Abort if anything goes wrong.
 set -euo pipefail
 
-# Decide what Rust toolchain to use.
+# Default to using OpenSSL 1.0 for a while longer, because 1.1 is
+# incompatible with the crates postgres 0.15 and openssl 0.9, which
+# are still widely used.
+OPENSSL_VERSION=1.0.2r
+
+# Pick an appropriate Docker tag
 case "$DOCKER_TAG" in
+  *-openssl11)
+    DOCKER_TAG_WITHOUT_OPENSSL="${DOCKER_TAG/-openssl11/}"
+    OPENSSL_VERSION=1.1.1b
+    ;;
+  *)
+    DOCKER_TAG_WITHOUT_OPENSSL="$DOCKER_TAG"
+    ;;
+esac
+
+# Decide what Rust toolchain to use.
+case "$DOCKER_TAG_WITHOUT_OPENSSL" in
   # Always map the Docker tags `latest` and `experimental` to stable Rust.
-  latest|experimental)
+  latest)
     TOOLCHAIN=stable
     ;;
   # Strip `experimental-` from other `experimental-*` tags.
   experimental-*)
-    TOOLCHAIN="${DOCKER_TAG/experimental-/}"
+    TOOLCHAIN="${DOCKER_TAG_WITHOUT_OPENSSL/experimental-/}"
     ;;
-  # Pass all our tags
+  # Pass all other tags through.
   *)
-    TOOLCHAIN="$DOCKER_TAG"
+    TOOLCHAIN="$DOCKER_TAG_WITHOUT_OPENSSL"
     ;;
 esac
 
 # Run the build.
-docker build --build-arg TOOLCHAIN="$TOOLCHAIN" -t "$IMAGE_NAME" .
+docker build \
+  --build-arg TOOLCHAIN="$TOOLCHAIN" \
+  --build-arg OPENSSL_VERSION="$OPENSSL_VERSION" \
+  -t "$IMAGE_NAME" \
+  .

--- a/hooks/build
+++ b/hooks/build
@@ -3,12 +3,21 @@
 # Abort if anything goes wrong.
 set -euo pipefail
 
-# Always map the Docker tag `latest` to stable Rust.
-if [ "$DOCKER_TAG" == "latest" ]; then
-  TOOLCHAIN=stable
-else
-  TOOLCHAIN="$DOCKER_TAG"
-fi
+# Decide what Rust toolchain to use.
+case "$DOCKER_TAG" in
+  # Always map the Docker tags `latest` and `experimental` to stable Rust.
+  latest|experimental)
+    TOOLCHAIN=stable
+    ;;
+  # Strip `experimental-` from other `experimental-*` tags.
+  experimental-*)
+    TOOLCHAIN="${DOCKER_TAG/experimental-/}"
+    ;;
+  # Pass all our tags
+  *)
+    TOOLCHAIN="$DOCKER_TAG"
+    ;;
+esac
 
 # Run the build.
 docker build --build-arg TOOLCHAIN="$TOOLCHAIN" -t "$IMAGE_NAME" .

--- a/hooks/test
+++ b/hooks/test
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Abort if anything goes wrong.
+set -euo pipefail
+
+# Make sure we can build some of our more important test images.
+for EXAMPLE in using-diesel; do
+    docker build -t rust-musl-builder-"$EXAMPLE" examples/"$EXAMPLE"
+done

--- a/hooks/test
+++ b/hooks/test
@@ -5,5 +5,8 @@ set -euo pipefail
 
 # Make sure we can build some of our more important test images.
 for EXAMPLE in using-diesel; do
-    docker build -t rust-musl-builder-"$EXAMPLE" examples/"$EXAMPLE"
+    docker build \
+        --build-arg BASE_IMAGE="$IMAGE_NAME" \
+        -t rust-musl-builder-"$EXAMPLE" \
+        examples/"$EXAMPLE"
 done


### PR DESCRIPTION
This PR contains lots of updates to underlying tools, including better testing before publishing images.