### PR TITLE
switching to GitHub hosted OpenSSL tar balls

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -94,8 +94,8 @@ RUN echo "Building OpenSSL" && \
     sudo ln -s /usr/include/x86_64-linux-gnu/asm /usr/local/musl/include/asm && \
     sudo ln -s /usr/include/asm-generic /usr/local/musl/include/asm-generic && \
     cd /tmp && \
-    curl -LO "https://www.openssl.org/source/openssl-$OPENSSL_VERSION.tar.gz" && \
-    tar xvzf "openssl-$OPENSSL_VERSION.tar.gz" && cd "openssl-$OPENSSL_VERSION" && \
+    curl -LO "https://github.com/openssl/openssl/archive/OpenSSL_$OPENSSL_VERSION.tar.gz" && \
+    tar xvzf "OpenSSL_$OPENSSL_VERSION.tar.gz" && cd "openssl-OpenSSL_$OPENSSL_VERSION" && \
     env CC=musl-gcc ./Configure no-shared no-zlib -fPIC --prefix=/usr/local/musl -DOPENSSL_NO_SECURE_MEMORY linux-x86_64 && \
     env C_INCLUDE_PATH=/usr/local/musl/include/ make depend && \
     env C_INCLUDE_PATH=/usr/local/musl/include/ make && \


### PR DESCRIPTION
Old URLs are now 404ing