### PR TITLE
Add cargo deb support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -156,6 +156,7 @@ ENV OPENSSL_DIR=/usr/local/musl/ \
 # We include cargo-audit for compatibility with earlier versions of this image,
 # but cargo-deny provides a super-set of cargo-audit's features.
 RUN cargo install -f cargo-audit && \
+    cargo install -f cargo-deb && \
     cargo install -f mdbook-graphviz && \
     rm -rf /home/rust/.cargo/registry/
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ This image also supports the following extra goodies:
 - Basic compilation for `armv7` using `musl-libc`. Not all libraries are supported at the moment, however.
 - [`mdbook`][mdbook] and `mdbook-graphviz` for building searchable HTML documentation from Markdown files. Build manuals to use alongside your `cargo doc` output!
 - [`cargo audit`][audit] to check your Rust project for known security issues.
+- [`cargo deb`][deb] to build Debian packages
 
 ## Making OpenSSL work
 
@@ -219,6 +220,7 @@ Either the [Apache 2.0 license](./LICENSE-APACHE.txt), or the
 
 [Alpine Linux container]: https://hub.docker.com/_/alpine/
 [audit]: https://github.com/RustSec/cargo-audit
+[deb]: https://github.com/mmstick/cargo-deb
 [mdbook]: https://github.com/rust-lang-nursery/mdBook
 [musl-libc]: http://www.musl-libc.org/
 [musl-gcc]: http://www.musl-libc.org/how.html


### PR DESCRIPTION
This PR adds support for building Debian packages using `cargo deb`.

Resolves #94 