### PR TITLE
Experimental: Improve support for `USER root`

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+examples/adding-a-library/target
+examples/linking-with-git2/target
+examples/using-diesel/target
+examples/using-sqlx/target

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 For maximum stablity, use images with tags like `ekidd/rust-musl-builder:1.46.0` or `ekidd/rust-musl-builder:nightly-2020-08-26`. These may occasionally be rebuilt, but only while they're "current", or possibly if they're recent and serious security are discovered in a library.
 
+## [UNRELEASED]
+
+This branch contains experimental changes intended to make it easier to support GitHub Actions.
+
+### Changed
+
+- You'll need to use `USER root` and `env RUSTUP_HOME=/opt/rust/rustup CARGO_HOME=/opt/rust/cargo rustup $ARGS` to install any new components.
+- `rustup`, `cargo`, and associated tools are all installed in `/opt/rust`, so that they should be available to the users `rust`, `root`, and any other users that get added.
+- Some other minor supporting tools like `git-credential-ghtoken` should now be available as `root`, as well.
+
+### Removed
+
+- ARM support has been removed, because it needs to be split into a separate base image. This would also allow us to build OpenSSL, etc., for ARM targets.
+- The `rust-docs` component is no longer installed by default.
+
 ## 2020-09-04
 
 ### Added

--- a/test-image
+++ b/test-image
@@ -15,32 +15,6 @@ docker run --rm rust-musl-builder-using-diesel
 
 echo "==== Verifying static linking"
 
-# Make sure we can build a static executable.
-docker run --rm ekidd/rust-musl-builder bash -c "
-set -euo pipefail
-export USER=rust
-cargo new --vcs none --bin testme
-cd testme
-
-echo -e '--- Test case for x86_64:'
-cargo build
-echo 'ldd says:'
-if ldd target/x86_64-unknown-linux-musl/debug/testme; then
-  echo '[FAIL] Executable is not static!' 1>&2
-  exit 1
-fi
-echo -e '[PASS] x86_64 binary is statically linked.\n'
-
-echo -e '--- Test case for ARMhf:'
-cargo build --target=armv7-unknown-linux-musleabihf
-echo 'ldd says:'
-if ldd target/armv7-unknown-linux-musleabihf/debug/testme; then
-  echo '[FAIL] Executable is not static!' 1>&2
-  exit 1
-fi
-echo -e '[PASS] ARMhf binary is statically linked.\n'
-"
-
 # Make sure we can build a static executable using `sqlx`.
 docker build -t rust-musl-builder-using-sqlx examples/using-sqlx
 docker run --rm rust-musl-builder-using-sqlx sh -c "


### PR DESCRIPTION
This PR attempts to lay the groundwork to address #96. In particular, we install the Rust toolchain globally by abusing `rustup`.

We still preserve the legacy `rust` user but we may start encouraging derived Dockerfiles to consider `USER root`.

This PR also removes ARM support. We want to explore the idea of supporting ARM more reliably using a separate image, but perhaps it would be better to refer those users to one of the Rust cross-compilation toolchains. See #63 for discussion.

Things to do before merging this to `master`:

- [ ] Figure out what we want to do with ARM.
- [ ] Wait until a new Rust release, and merge then, to minimize disruption caused by overwriting `latest`, etc., with something incompatible.