### PR TITLE
Fix name of ghtoken binary in image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -97,7 +97,7 @@ ADD cargo-config.toml /home/rust/.cargo/config
 
 # Set up a `git credentials` helper for using GH_USER and GH_TOKEN to access
 # private repositories if desired.
-ADD git-credential-ghtoken /usr/local/bin/ghtoken
+ADD git-credential-ghtoken /usr/local/bin/git-credential-ghtoken
 RUN git config --global credential.https://github.com.helper ghtoken
 
 # Build a static library version of OpenSSL using musl-libc.  This is needed by


### PR DESCRIPTION
Renames `ghtoken` to the expected `git-credential-ghtoken` to resolve the following issue:
```
rust@1adcf00e7df0:~/src$ git clone https://github.com/myorg/private-repo
Cloning into 'private-repo'...
git: 'credential-ghtoken' is not a git command. See 'git --help'.
```