### PR TITLE
Set RUSTUP_HOME and CARGO_HOME for building as root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -149,7 +149,9 @@ ENV X86_64_UNKNOWN_LINUX_MUSL_OPENSSL_DIR=/usr/local/musl/ \
     PKG_CONFIG_ALLOW_CROSS=true \
     PKG_CONFIG_ALL_STATIC=true \
     LIBZ_SYS_STATIC=1 \
-    TARGET=musl
+    TARGET=musl \
+    RUSTUP_HOME=/home/rust/.rustup \
+    CARGO_HOME=/home/rust/.cargo
 
 # (Please feel free to submit pull requests for musl-libc builds of other C
 # libraries needed by the most popular and common Rust crates, to avoid


### PR DESCRIPTION
This is the minimal change needed to allow the docker image to be run
with `--user root` and still build correctly.

There may be better long-term ways of doing this, but hopefully this is
small enough to be uncontroversial.

This isn't a breaking change for users running normally (as the `rust`
user) because these are already the default paths.

Refs: https://github.com/emk/rust-musl-builder/issues/96
Refs: https://github.com/emk/rust-musl-builder/pull/100