### PR TITLE
fix: update mdbook version due to CVE-2020-26297

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ ARG OPENSSL_VERSION=1.1.1i
 #
 # We're stuck on PostgreSQL 11 until we figure out
 # https://github.com/emk/rust-musl-builder/issues.
-ARG MDBOOK_VERSION=0.4.4
+ARG MDBOOK_VERSION=0.4.5
 ARG CARGO_ABOUT_VERSION=0.2.3
 ARG CARGO_DENY_VERSION=0.8.5
 ARG ZLIB_VERSION=1.2.11


### PR DESCRIPTION
Earlier today rust released a [blog post](https://blog.rust-lang.org/2021/01/04/mdbook-security-advisory.html) for the mdBook security advisory for [CVE-2020-26297](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-26297). 

This is a super basic PR that bumps the mdbook version from 0.4.4 to 0.4.5.