### PR TITLE
README: use proper language identifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ compile [examples/using-diesel](./examples/using-diesel) and [examples/using-sql
 
 You may be able to speed up build performance by adding the following `-v` commands to the `rust-musl-builder` alias:
 
-```txt
+```sh
 -v cargo-git:/home/rust/.cargo/git
 -v cargo-registry:/home/rust/.cargo/registry
 -v target:/home/rust/src/target
@@ -114,7 +114,7 @@ openssl = "*"
 
 For PostgreSQL, you'll also need to include `diesel` and `openssl` in your `main.rs` in the following order (in order to avoid linker errors):
 
-```toml
+```rust
 extern crate openssl;
 #[macro_use]
 extern crate diesel;
@@ -155,7 +155,7 @@ Next, copy [`build-release`](./examples/build-release) into your project and run
 
 Finally, add a `Dockerfile` to perform the actual build:
 
-```rust
+```Dockerfile
 FROM ekidd/rust-musl-builder
 
 # We need to add the source code to the image because `rust-musl-builder`


### PR DESCRIPTION
`rust` where appropriate, `Dockerfile` where appropriate ...