### PR TITLE
WIP: Switch to cross-compilation toolchain to allow compilation on M1 CPUs

### DIFF
--- a/cargo-config.toml
+++ b/cargo-config.toml
@@ -4,3 +4,6 @@ target = "x86_64-unknown-linux-musl"
 
 [target.armv7-unknown-linux-musleabihf]
 linker = "arm-linux-gnueabihf-gcc"
+
+[target.x86_64-unknown-linux-musl]
+linker = "/usr/local/musl-x86_64/bin/x86_64-linux-musl-gcc"

--- a/cargo-config.toml
+++ b/cargo-config.toml
@@ -4,6 +4,3 @@ target = "x86_64-unknown-linux-musl"
 
 [target.armv7-unknown-linux-musleabihf]
 linker = "arm-linux-gnueabihf-gcc"
-
-[target.x86_64-unknown-linux-musl]
-linker = "/usr/local/musl-x86_64/bin/x86_64-linux-musl-gcc"


### PR DESCRIPTION
This is a basic implementation of support for cross-compiling Rust crates from an `aarch64` CPU like the new M1 chips in MacBooks to a statically linked `x86_64-unknown-linux-musl` binary.

It does not break any of the tests for the image on regular x86 machines. However, the current state of the PR does fail when trying the Diesel test compilation. Regardless, it is a step forwards and as long as the `libpq` is not required, it works.

@emk please let me know on how you'd like to proceed. In my eyes having the ability to at least compile some crates (including OpenSSL) is already a huge gain and since it does not appear to break the regular x86 compilation, it would make sense to merge these changes. However, publishing the aarch64 image on Docker-Hub requires integration in your publishing workflow. Let me know your thoughts 🙂

Related to #117 