### PR TITLE
Ubuntu 20.04

### DIFF
--- a/examples/linking-with-git2/Dockerfile
+++ b/examples/linking-with-git2/Dockerfile
@@ -11,3 +11,11 @@ ADD --chown=rust:rust . ./
 
 # Build our application.
 RUN cargo build
+
+# Now, we need to build our _real_ Docker container, copying in `linking-with-git2`.
+FROM debian:stretch-slim
+RUN apt-get update && apt-get install -y ca-certificates
+COPY --from=builder \
+  /home/rust/src/target/x86_64-unknown-linux-musl/debug/linking-with-git2 \
+  /usr/local/bin/
+CMD /usr/local/bin/linking-with-git2

--- a/examples/using-sqlx/Dockerfile
+++ b/examples/using-sqlx/Dockerfile
@@ -17,8 +17,8 @@ ADD --chown=rust:rust . ./
 RUN cargo build --release
 
 # Now, we need to build our _real_ Docker container, copying in `using-sqlx`.
-FROM alpine:latest
-RUN apk --no-cache add ca-certificates
+FROM debian:stretch-slim
+RUN apt-get update && apt-get install -y ca-certificates
 COPY --from=builder \
     /home/rust/src/target/x86_64-unknown-linux-musl/release/using-sqlx \
     /usr/local/bin/

--- a/test-image
+++ b/test-image
@@ -17,12 +17,14 @@ echo "==== Verifying static linking"
 
 # Make sure we can build a static executable using `sqlx`.
 docker build -t rust-musl-builder-using-sqlx examples/using-sqlx
-docker run --rm rust-musl-builder-using-sqlx sh -c "
+docker run --rm rust-musl-builder-using-sqlx bash -c "
 set -euo pipefail
 
 echo -e '--- Test case for sqlx:'
 echo 'ldd says:'
-if ldd /usr/local/bin/using-sqlx; then
+lddresult=\$(ldd /usr/local/bin/using-sqlx)
+echo \$lddresult
+if [[ "\$lddresult" != *statically\ linked* ]]; then
   echo '[FAIL] Executable is not static!' 1>&2
   exit 1
 fi
@@ -33,14 +35,16 @@ echo -e '[PASS] using-sqlx binary is statically linked.\n'
 docker build -t rust-musl-builder-linking-with-git2 examples/linking-with-git2
 docker run --rm rust-musl-builder-linking-with-git2 bash -c "
 set -euo pipefail
-cd /home/rust/src
 
 echo -e '--- Test case for libgit2:'
 echo 'ldd says:'
-if ldd target/x86_64-unknown-linux-musl/debug/linking-with-git2; then
+lddresult=\$(ldd /usr/local/bin/linking-with-git2)
+echo \$lddresult
+if [[ "\$lddresult" != *statically\ linked* ]]; then
   echo '[FAIL] Executable is not static!' 1>&2
   exit 1
 fi
+
 echo -e '[PASS] libgit2 binary is statically linked.\n'
 "
 


### PR DESCRIPTION
Use latest ubuntu LTS release (20.04)

Also:
- Update mdbook to 0.4.7
- Update cargo-about to 0.3.0
- Update cargo-deny to 0.9.0

---

Travis CI checks can be found under my PR of the fork: asaaki/rust-musl-builder#1
If you want to use the image already:

```Dockerfile
FROM ghcr.io/asaaki/rust-musl-builder:latest
```

Closes #98