### PR TITLE
Use GitHub Actions for CI

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,34 @@
+name: Build and Publish Docker image
+
+on: push
+
+# https://docs.github.com/en/actions/guides/publishing-docker-images
+
+jobs:
+  build_image:
+    name: Build image and push to Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+
+
+      # - name: Log in to Docker Hub
+      #   uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+      #   with:
+      #     username: ${{ secrets.DOCKER_USERNAME }}
+      #     password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ekidd/rust-musl-builder
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          # push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Since Docker Hub limited the free CI hours, this image could not be built and published anymore.

This PR tries to use GitHub Actions to build and publish the image.

Building itself works, but I commented the actual push and the login to Docker Hub for my tests. In general it seems to work. Maybe this helps making newer versions of the image available again.

Closes https://github.com/emk/rust-musl-builder/issues/123 https://github.com/emk/rust-musl-builder/issues/122 and https://github.com/emk/rust-musl-builder/issues/121