### PR TITLE
Fix failing Builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ARG TOOLCHAIN=stable
 # - https://www.openssl.org/source/
 #
 # ALSO UPDATE hooks/build!
-ARG OPENSSL_VERSION=1.1.1m
+ARG OPENSSL_VERSION=1.1.1q
 
 # Versions for other dependencies. Here are the places to check for new
 # releases:
@@ -24,13 +24,13 @@ ARG OPENSSL_VERSION=1.1.1m
 #
 # We're stuck on PostgreSQL 11 until we figure out
 # https://github.com/emk/rust-musl-builder/issues.
-ARG MDBOOK_VERSION=0.4.14
+ARG MDBOOK_VERSION=0.4.21
 ARG MDBOOK_GRAPHVIZ_VERSION=0.1.3
-ARG CARGO_ABOUT_VERSION=0.4.4
-ARG CARGO_AUDIT_VERSION=0.16.0
-ARG CARGO_DENY_VERSION=0.11.0
-ARG ZLIB_VERSION=1.2.11
-ARG POSTGRESQL_VERSION=11.14
+ARG CARGO_ABOUT_VERSION=0.5.1
+ARG CARGO_AUDIT_VERSION=0.17.0
+ARG CARGO_DENY_VERSION=0.12.2
+ARG ZLIB_VERSION=1.2.12
+ARG POSTGRESQL_VERSION=11.17
 
 # Make sure we have basic dev tools for building C libraries.  Our goal here is
 # to support the musl-libc builds and Cargo builds needed for a large selection
@@ -66,7 +66,7 @@ RUN apt-get update && \
 # - `cargo-about` generates a giant license file for all dependencies.
 # - `cargo-audit` checks for security vulnerabilities. We include it for backwards compat.
 # - `cargo-deny` does everything `cargo-audit` does, plus check licenses & many other things.
-RUN curl -fLO https://github.com/rust-lang-nursery/mdBook/releases/download/v$MDBOOK_VERSION/mdbook-v$MDBOOK_VERSION-x86_64-unknown-linux-gnu.tar.gz && \
+RUN curl -fLO https://github.com/rust-lang/mdBook/releases/download/v$MDBOOK_VERSION/mdbook-v$MDBOOK_VERSION-x86_64-unknown-linux-gnu.tar.gz && \
     tar xf mdbook-v$MDBOOK_VERSION-x86_64-unknown-linux-gnu.tar.gz && \
     mv mdbook /usr/local/bin/ && \
     rm -f mdbook-v$MDBOOK_VERSION-x86_64-unknown-linux-gnu.tar.gz && \

--- a/examples/adding-a-library/Dockerfile
+++ b/examples/adding-a-library/Dockerfile
@@ -8,7 +8,7 @@ FROM ekidd/rust-musl-builder
 # Build a static copy of zlib.
 #
 # EXAMPLE ONLY! libz is already included.
-RUN VERS=1.2.11 && \
+RUN VERS=1.2.12 && \
     cd /home/rust/libs && \
     curl -LO http://zlib.net/zlib-$VERS.tar.gz && \
     tar xzf zlib-$VERS.tar.gz && cd zlib-$VERS && \


### PR DESCRIPTION
This PR updates the library versions, thereby fixing the currently failing builds. The problem was zlib 1.2.11 being "unreleased" due to bug fixes.

The [`zlib` homepage](https://zlib.net/) states `Due to the bug fixes, any installations of 1.2.11 should be replaced with 1.2.12.`

While at it, I also updated the versions for OpenSSL, mdBook, cargo-about, cargo-audit, cargo-deny and Postgres.

With these changes, the scheduled releases should work again.